### PR TITLE
Updated location cards to use smaller images from Cloudinary

### DIFF
--- a/Components/Location Card/locationCard.js
+++ b/Components/Location Card/locationCard.js
@@ -4,14 +4,16 @@ import Link from 'next/link';
 import Button from '../Button/button';
 import Tooltip from '@mui/material/Tooltip';
 
-//get props to location page
 
 export default function LocationCard({ location }) {
+  const url = location.image_url
+  const urlForSmallImage = url.slice(0, url.indexOf('upload') + 7) + 'c_scale,h_250/' + url.slice(url.indexOf('upload') + 7)
+  
   return (
     <div className={styles.card}>
       <img
         className={styles.card_img}
-        src={location.image_url}
+        src={urlForSmallImage}
         alt="Location"
       />
       <section className={styles.card_details}>


### PR DESCRIPTION
- Created a transformation in Cloudinary for obtaining images at a smaller size (250px height)
- Updated the card displays on the home page to obtain the smaller versions of each image, to increase the loading speed of the home page